### PR TITLE
Fix scripts/generate-data.sh

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LDBC_SNB_DATAGEN_VERSION=v0.3.3
+LDBC_SNB_DATAGEN_VERSION=0.3.3
 HADOOP_VERSION=3.2.1
 
 scaleFactor=${scaleFactor:-1}

--- a/scripts/generate-data.sh
+++ b/scripts/generate-data.sh
@@ -45,7 +45,7 @@ else
   rm -rf ldbc_snb_datagen && \
   wget https://github.com/ldbc/ldbc_snb_datagen_hadoop/archive/refs/tags/v${LDBC_SNB_DATAGEN_VERSION}.tar.gz && \
   tar -zxvf v${LDBC_SNB_DATAGEN_VERSION}.tar.gz  && \
-  mv v${LDBC_SNB_DATAGEN_VERSION}.tar.gz ldbc_snb_datagen  && \
+  mv ldbc_snb_datagen_hadoop-${LDBC_SNB_DATAGEN_VERSION} ldbc_snb_datagen  && \
   cd ldbc_snb_datagen  && \
   cp test_params.ini params.ini
 fi

--- a/scripts/generate-data.sh
+++ b/scripts/generate-data.sh
@@ -43,7 +43,9 @@ if [ -d ${DATA_DIR}/ldbc_snb_datagen ];then
 else
   cd ${DATA_DIR}  && \
   rm -rf ldbc_snb_datagen && \
-  git clone --branch ${LDBC_SNB_DATAGEN_VERSION} https://github.com/ldbc/ldbc_snb_datagen && \
+  wget https://github.com/ldbc/ldbc_snb_datagen_hadoop/archive/refs/tags/v${LDBC_SNB_DATAGEN_VERSION}.tar.gz && \
+  tar -zxvf v${LDBC_SNB_DATAGEN_VERSION}.tar.gz  && \
+  mv v${LDBC_SNB_DATAGEN_VERSION}.tar.gz ldbc_snb_datagen  && \
   cd ldbc_snb_datagen  && \
   cp test_params.ini params.ini
 fi


### PR DESCRIPTION
Currently the address for github repo of ldbc_snb_datagen for hadoop has changed. The `generate-data.sh` now **redirects the address to ldbc_snb_datagen for spark instead of hadoop.** Therefore, I cannot download the correct package to generate data.

The latest repo address should be: https://github.com/ldbc/ldbc_snb_datagen_hadoop. And the v0.3.3 package can use `wget` to download, which is `wget https://github.com/ldbc/ldbc_snb_datagen_hadoop/archive/refs/tags/v0.3.3.tar.gz`. 
In the script, I use `${LDBC_SNB_DATAGEN_VERSION}` to represent the version number.